### PR TITLE
removed http:// to work also with https

### DIFF
--- a/action.php
+++ b/action.php
@@ -44,7 +44,7 @@ class action_plugin_googlefonts extends DokuWiki_Action_Plugin {
 		}
 
         $CSSfiles = array(
-			'http://fonts.googleapis.com/css?family='.trim(implode("|",str_replace(' ', '+', $fontNames)),"|")
+			'//fonts.googleapis.com/css?family='.trim(implode("|",str_replace(' ', '+', $fontNames)),"|")
 		);
 
         // include all relevant CSS files


### PR DESCRIPTION
Hello!

We run our DokuWiki with HTTPS and your plugin does not work because it includes unsafe http items.

Can you please accept the pull request to support https.

greetings from munich, sebastian
